### PR TITLE
Fix for `aarch64-apple-darwin` target

### DIFF
--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,7 +1,12 @@
 use elf_loader::arch::{ElfPhdr, TLS_DTV_OFFSET};
+
+#[cfg(not(target_os = "macos"))]
+use libc::__errno_location;
+#[cfg(target_os = "macos")]
+use libc::__error as __errno_location;
+
 use libc::{
-    __errno_location, pthread_getspecific, pthread_key_create, pthread_key_delete, pthread_key_t,
-    pthread_setspecific,
+    pthread_getspecific, pthread_key_create, pthread_key_delete, pthread_key_t, pthread_setspecific,
 };
 use std::{
     alloc::{Layout, dealloc, handle_alloc_error},


### PR DESCRIPTION
In the `libc` crate, `__errno_location` seems to be called just `__error` for the `macos` target.

This is supposed to be a partial fix for AhoyISki/duat#2, since I don't really know what would need to be done in order to fix the rest of that error message.